### PR TITLE
[Workflow] Linter action 

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: black formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--line-length 80 --verbose"
+          src: "./promptmeteo"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--line-length 80 --verbose"
+          options: "--line-length 80 --verbose --diff --color"
           src: "./promptmeteo"


### PR DESCRIPTION
Add a new action to lint the `./promptmeteo` code with [Black](https://black.readthedocs.io/). Based on the [official documentation](https://black.readthedocs.io/en/stable/integrations/github_actions.html) using a 80 character line length.