### PR TITLE
Remove pandoc dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ docs = [
     "furo==2024.1.29",
     "numpydoc==1.6.0",
     "sphinxcontrib-napoleon==0.7",
-    "pandoc==2.3",
     "nbsphinx==0.9.3",
 ]
 openai = [


### PR DESCRIPTION
Pandoc is necessary to render notebooks as html files in docs, but it's intalled via apt-get, so it should be listed in the Readme instead of the pyproject file.

Closes #24.